### PR TITLE
Add internal memory

### DIFF
--- a/pympipool/__init__.py
+++ b/pympipool/__init__.py
@@ -97,7 +97,7 @@ class Pool(Executor):
 
 
 class Worker(Executor):
-    def __init__(self, cores, oversubscribe=False, enable_flux_backend=False):
+    def __init__(self, cores, oversubscribe=False, enable_flux_backend=False, init_function=None):
         self._future_queue = Queue()
         self._process = Thread(
             target=execute_tasks,
@@ -105,6 +105,8 @@ class Worker(Executor):
         )
         self._process.start()
         _cloudpickle_update(ind=2)
+        if init_function is not None:
+            self._future_queue.put({"i": True, "f": init_function, "a": (), "k": {}})
 
     def submit(self, fn, *args, **kwargs):
         f = Future()

--- a/pympipool/__init__.py
+++ b/pympipool/__init__.py
@@ -97,7 +97,9 @@ class Pool(Executor):
 
 
 class Worker(Executor):
-    def __init__(self, cores, oversubscribe=False, enable_flux_backend=False, init_function=None):
+    def __init__(
+        self, cores, oversubscribe=False, enable_flux_backend=False, init_function=None
+    ):
         self._future_queue = Queue()
         self._process = Thread(
             target=execute_tasks,

--- a/pympipool/executor/mpiexec.py
+++ b/pympipool/executor/mpiexec.py
@@ -25,6 +25,7 @@ def main():
         context = None
         socket = None
 
+    memory = None
     while True:
         # Read from socket
         if mpi_rank_zero:
@@ -39,16 +40,20 @@ def main():
                 socket.close()
                 context.term()
             break
-        elif "f" in input_dict.keys() and (
+        elif "f" in input_dict.keys() and "i" not in input_dict.keys() and (
             "a" in input_dict.keys() or "k" in input_dict.keys()
         ):
             # Execute function
-            output = call_funct(input_dict=input_dict, funct=None)
+            output = call_funct(input_dict=input_dict, funct=None, memory=memory)
             output_reply = MPI.COMM_WORLD.gather(output, root=0)
 
             # Send output
             if mpi_rank_zero:
                 socket.send(cloudpickle.dumps({"r": output_reply}))
+        elif "i" in input_dict.keys() and input_dict["i"] and (
+                "a" in input_dict.keys() or "k" in input_dict.keys()
+        ):
+            memory = call_funct(input_dict=input_dict, funct=None)
 
 
 if __name__ == "__main__":

--- a/pympipool/executor/mpiexec.py
+++ b/pympipool/executor/mpiexec.py
@@ -40,8 +40,10 @@ def main():
                 socket.close()
                 context.term()
             break
-        elif "f" in input_dict.keys() and "i" not in input_dict.keys() and (
-            "a" in input_dict.keys() or "k" in input_dict.keys()
+        elif (
+            "f" in input_dict.keys()
+            and "i" not in input_dict.keys()
+            and ("a" in input_dict.keys() or "k" in input_dict.keys())
         ):
             # Execute function
             output = call_funct(input_dict=input_dict, funct=None, memory=memory)
@@ -50,8 +52,10 @@ def main():
             # Send output
             if mpi_rank_zero:
                 socket.send(cloudpickle.dumps({"r": output_reply}))
-        elif "i" in input_dict.keys() and input_dict["i"] and (
-                "a" in input_dict.keys() or "k" in input_dict.keys()
+        elif (
+            "i" in input_dict.keys()
+            and input_dict["i"]
+            and ("a" in input_dict.keys() or "k" in input_dict.keys())
         ):
             memory = call_funct(input_dict=input_dict, funct=None)
 

--- a/pympipool/share/parallel.py
+++ b/pympipool/share/parallel.py
@@ -68,8 +68,9 @@ def call_funct(input_dict, funct=None, memory=None):
         def funct(*args, **kwargs):
             return args[0].__call__(*args[1:], **kwargs)
 
-    if memory is not None and "memory" in inspect.getfullargspec(input_dict["f"]).args:
-        input_dict["k"]["memory"] = memory
+    funct_args = inspect.getfullargspec(input_dict["f"]).args
+    if memory is not None:
+        input_dict["k"].update({k: v for k, v in memory.items() if k in funct_args})
 
     if "a" in input_dict.keys() and "k" in input_dict.keys():
         return funct(input_dict["f"], *input_dict["a"], **input_dict["k"])

--- a/pympipool/share/parallel.py
+++ b/pympipool/share/parallel.py
@@ -61,11 +61,14 @@ def map_funct(executor, funct, lst, cores_per_task):
         ]
 
 
-def call_funct(input_dict, funct=None):
+def call_funct(input_dict, funct=None, memory=None):
     if funct is None:
 
         def funct(*args, **kwargs):
             return args[0].__call__(*args[1:], **kwargs)
+
+    if memory is not None:
+        input_dict["k"]["memory"] = memory
 
     if "a" in input_dict.keys() and "k" in input_dict.keys():
         return funct(input_dict["f"], *input_dict["a"], **input_dict["k"])

--- a/pympipool/share/parallel.py
+++ b/pympipool/share/parallel.py
@@ -1,3 +1,4 @@
+import inspect
 import zmq
 from tqdm import tqdm
 
@@ -67,7 +68,7 @@ def call_funct(input_dict, funct=None, memory=None):
         def funct(*args, **kwargs):
             return args[0].__call__(*args[1:], **kwargs)
 
-    if memory is not None:
+    if memory is not None and "memory" in inspect.getfullargspec(input_dict["f"]).args:
         input_dict["k"]["memory"] = memory
 
     if "a" in input_dict.keys() and "k" in input_dict.keys():

--- a/pympipool/share/serial.py
+++ b/pympipool/share/serial.py
@@ -99,3 +99,5 @@ def execute_tasks(future_queue, cores, oversubscribe, enable_flux_backend):
                     )
                 else:
                     f.set_result(interface.send_and_receive_dict(input_dict=task_dict))
+        elif "f" in task_dict.keys() and "i" in task_dict.keys():
+            interface.send_dict(input_dict=task_dict)

--- a/tests/test_worker_memory.py
+++ b/tests/test_worker_memory.py
@@ -1,0 +1,20 @@
+import unittest
+import numpy as np
+from pympipool import Worker
+
+
+def get_global(memory=None):
+    return memory
+
+
+def set_global():
+    return np.array([5])
+
+
+class TestWorkerMemory(unittest.TestCase):
+    def test_internal_memory(self):
+        with Worker(cores=1, init_function=set_global) as p:
+            f = p.submit(get_global)
+            self.assertFalse(f.done())
+            self.assertEqual(f.result(), np.array([5]))
+            self.assertTrue(f.done())

--- a/tests/test_worker_memory.py
+++ b/tests/test_worker_memory.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
 from pympipool import Worker
+from pympipool.share.parallel import call_funct
 
 
 def get_global(memory=None):
@@ -18,3 +19,9 @@ class TestWorkerMemory(unittest.TestCase):
             self.assertFalse(f.done())
             self.assertEqual(f.result(), np.array([5]))
             self.assertTrue(f.done())
+
+    def test_call_funct(self):
+        self.assertEqual(call_funct(
+            input_dict={"f": get_global, "a": (), "k": {}},
+            memory={"memory": 4}
+        ), 4)

--- a/tests/test_worker_memory.py
+++ b/tests/test_worker_memory.py
@@ -8,7 +8,7 @@ def get_global(memory=None):
 
 
 def set_global():
-    return np.array([5])
+    return {"memory": np.array([5])}
 
 
 class TestWorkerMemory(unittest.TestCase):


### PR DESCRIPTION
The LAMMPS instance is defined once when the worker is initialized and then all other functions interact with this LAMMPS instance: 
```
>>> from pympipool import Worker
>>> 
>>> def get_global(lmp):
>>>     return lmp.version()
>>> 
>>> def set_global():
>>>     from mpi4py import MPI
>>>     from lammps import lammps
>>>     return {"lmp": lammps(comm=MPI.COMM_WORLD), "a": 1}
>>> 
>>> exe = Worker(cores=1, init_function=set_global)
>>> fs1 = exe.submit(get_global)
>>> fs1.result()  
20230328
```