### PR TITLE
Specify sync interval - force short sleep

### DIFF
--- a/pympipool/share/executor.py
+++ b/pympipool/share/executor.py
@@ -116,6 +116,7 @@ class PoolExecutor(ExecutorBase):
         oversubscribe=False,
         enable_flux_backend=False,
         cwd=None,
+        sleep_interval=0.1
     ):
         super().__init__()
         self._process = Thread(
@@ -126,6 +127,7 @@ class PoolExecutor(ExecutorBase):
                 oversubscribe,
                 enable_flux_backend,
                 cwd,
+                sleep_interval,
             ),
         )
         self._process.start()

--- a/pympipool/share/serial.py
+++ b/pympipool/share/serial.py
@@ -1,6 +1,7 @@
 import inspect
 import os
 import socket
+import time
 import queue
 
 import cloudpickle
@@ -106,7 +107,7 @@ def execute_parallel_tasks(
 
 
 def execute_serial_tasks(
-    future_queue, cores, oversubscribe=False, enable_flux_backend=False, cwd=None
+    future_queue, cores, oversubscribe=False, enable_flux_backend=False, cwd=None, sleep_interval=0.1
 ):
     future_dict = {}
     interface = SocketInterface()
@@ -134,10 +135,11 @@ def execute_serial_tasks(
                 f = task_dict.pop("future")
                 future_hash = interface.send_and_receive_dict(input_dict=task_dict)
                 future_dict[future_hash] = f
-        update_future_dict(interface=interface, future_dict=future_dict)
+        update_future_dict(interface=interface, future_dict=future_dict, sleep_interval=sleep_interval)
 
 
-def update_future_dict(interface, future_dict):
+def update_future_dict(interface, future_dict, sleep_interval=0.1):
+    time.sleep(sleep_interval)
     hash_to_update = [h for h, f in future_dict.items() if not f.done()]
     hash_to_cancel = [h for h, f in future_dict.items() if f.cancelled()]
     if len(hash_to_update) > 0:


### PR DESCRIPTION
The challenge is keeping the future objects in the serial python process and the MPI parallel python process in sync. The user could cancel the future object from the serial python process or the execution of a given future object could be completed resulting in a state change in the parallel python process. For most cases 1/10 of a second seems to be appropriate, still the user can manually adjust this value if necessary.