### PR TITLE
Pyzmq downgrade - for compatibility with maggma

### DIFF
--- a/.ci_support/environment-mpich.yml
+++ b/.ci_support/environment-mpich.yml
@@ -7,4 +7,4 @@ dependencies:
 - cloudpickle =2.2.1
 - mpi4py =3.1.4
 - tqdm =4.66.1
-- pyzmq =25.1.1
+- pyzmq =22.3.0

--- a/.ci_support/environment-mpich.yml
+++ b/.ci_support/environment-mpich.yml
@@ -7,4 +7,4 @@ dependencies:
 - cloudpickle =2.2.1
 - mpi4py =3.1.4
 - tqdm =4.66.1
-- pyzmq =22.3.0
+- pyzmq =24.0.1

--- a/.ci_support/environment-openmpi.yml
+++ b/.ci_support/environment-openmpi.yml
@@ -7,4 +7,4 @@ dependencies:
 - cloudpickle =2.2.1
 - mpi4py =3.1.4
 - tqdm =4.66.1
-- pyzmq =25.1.1
+- pyzmq =22.3.0

--- a/.ci_support/environment-openmpi.yml
+++ b/.ci_support/environment-openmpi.yml
@@ -7,4 +7,4 @@ dependencies:
 - cloudpickle =2.2.1
 - mpi4py =3.1.4
 - tqdm =4.66.1
-- pyzmq =22.3.0
+- pyzmq =24.0.1

--- a/.ci_support/environment-win.yml
+++ b/.ci_support/environment-win.yml
@@ -7,4 +7,4 @@ dependencies:
 - cloudpickle =2.2.1
 - mpi4py =3.1.4
 - tqdm =4.66.1
-- pyzmq =25.1.1
+- pyzmq =22.3.0

--- a/.ci_support/environment-win.yml
+++ b/.ci_support/environment-win.yml
@@ -7,4 +7,4 @@ dependencies:
 - cloudpickle =2.2.1
 - mpi4py =3.1.4
 - tqdm =4.66.1
-- pyzmq =22.3.0
+- pyzmq =24.0.1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'cloudpickle==2.2.1',
         'mpi4py==3.1.4',
         'tqdm==4.66.1',
-        'pyzmq==22.3.0',
+        'pyzmq==24.0.1',
     ],
     cmdclass=versioneer.get_cmdclass(),
 )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'cloudpickle==2.2.1',
         'mpi4py==3.1.4',
         'tqdm==4.66.1',
-        'pyzmq==25.1.1',
+        'pyzmq==22.3.0',
     ],
     cmdclass=versioneer.get_cmdclass(),
 )


### PR DESCRIPTION
```
maggma 0.46.1 has requirement pyzmq==22.3.0, but you have pyzmq 25.1.1.
```