### PR TITLE
Ci differences

### DIFF
--- a/.github/workflows/unittest_by_path.yml
+++ b/.github/workflows/unittest_by_path.yml
@@ -1,0 +1,45 @@
+# This workflow is used to run the unittest of pyiron
+
+name: Unittests-openmpi
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        include:
+          
+        - operating-system: ubuntu-latest
+          python-version: '3.11'
+          label: linux-64-py-3-11-openmpi
+          prefix: /usr/share/miniconda3/envs/my-env
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2.2.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        mamba-version: "*"
+        channels: conda-forge
+        miniforge-variant: Mambaforge
+        channel-priority: strict
+        auto-update-conda: true
+        environment-file: .ci_support/environment-openmpi.yml
+    - name: Test
+      shell: bash -l {0}
+      timeout-minutes: 5
+      run: |
+        pip install versioneer[toml]==0.29
+        pip install . --no-deps --no-build-isolation
+        python -m unittest discover tests
+      env:
+        OMPI_MCA_plm: 'isolated'
+        OMPI_MCA_rmaps_base_oversubscribe: 'yes'
+        OMPI_MCA_btl_vader_single_copy_mechanism: 'none'

--- a/.github/workflows/unittest_by_path.yml
+++ b/.github/workflows/unittest_by_path.yml
@@ -1,6 +1,6 @@
 # This workflow is used to run the unittest of pyiron
 
-name: Unittests-openmpi
+name: Unittests_by_path
 
 on:
   push:

--- a/.github/workflows/unittest_by_path_with_env.yml
+++ b/.github/workflows/unittest_by_path_with_env.yml
@@ -1,6 +1,6 @@
 # This workflow is used to run the unittest of pyiron
 
-name: Unittests-openmpi
+name: Unittests_by_path_with_env
 
 on:
   push:

--- a/.github/workflows/unittest_by_path_with_env.yml
+++ b/.github/workflows/unittest_by_path_with_env.yml
@@ -1,0 +1,49 @@
+# This workflow is used to run the unittest of pyiron
+
+name: Unittests-openmpi
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        include:
+          
+        - operating-system: ubuntu-latest
+          python-version: '3.11'
+          label: linux-64-py-3-11-openmpi
+          prefix: /usr/share/miniconda3/envs/my-env
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2.2.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        mamba-version: "*"
+        channels: conda-forge
+        miniforge-variant: Mambaforge
+        channel-priority: strict
+        auto-update-conda: true
+        environment-file: .ci_support/environment-openmpi.yml
+    - name: Setup env
+      run: |
+        PWD=$(pwd)
+        echo "PYTHONPATH=$PWD/tests:$PYTHONPATH" >> $GITHUB_ENV
+    - name: Test
+      shell: bash -l {0}
+      timeout-minutes: 5
+      run: |
+        pip install versioneer[toml]==0.29
+        pip install . --no-deps --no-build-isolation
+        python -m unittest discover tests
+      env:
+        OMPI_MCA_plm: 'isolated'
+        OMPI_MCA_rmaps_base_oversubscribe: 'yes'
+        OMPI_MCA_btl_vader_single_copy_mechanism: 'none'

--- a/.github/workflows/unittest_by_path_with_pythonpath.yml
+++ b/.github/workflows/unittest_by_path_with_pythonpath.yml
@@ -1,0 +1,47 @@
+# This workflow is used to run the unittest of pyiron
+
+name: Unittests-openmpi
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        include:
+          
+        - operating-system: ubuntu-latest
+          python-version: '3.11'
+          label: linux-64-py-3-11-openmpi
+          prefix: /usr/share/miniconda3/envs/my-env
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2.2.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        mamba-version: "*"
+        channels: conda-forge
+        miniforge-variant: Mambaforge
+        channel-priority: strict
+        auto-update-conda: true
+        environment-file: .ci_support/environment-openmpi.yml
+    - name: Test
+      shell: bash -l {0}
+      timeout-minutes: 5
+      run: |
+        pip install versioneer[toml]==0.29
+        pip install . --no-deps --no-build-isolation
+        PWD=$(pwd)
+        export PYTHONPATH=$PWD/tests:$PYTHONPATH
+        python -m unittest discover tests
+      env:
+        OMPI_MCA_plm: 'isolated'
+        OMPI_MCA_rmaps_base_oversubscribe: 'yes'
+        OMPI_MCA_btl_vader_single_copy_mechanism: 'none'

--- a/.github/workflows/unittest_by_path_with_pythonpath.yml
+++ b/.github/workflows/unittest_by_path_with_pythonpath.yml
@@ -1,6 +1,6 @@
 # This workflow is used to run the unittest of pyiron
 
-name: Unittests-openmpi
+name: Unittests_by_path_with_pythonpath
 
 on:
   push:


### PR DESCRIPTION
In `pyiron_workflow` I'm [running into a problem](https://github.com/pyiron/actions/blob/main/.github/workflows/push-pull-main.yml#L134) where the tests hang, and when cancelled I ultimately get pympipool complaints that the test files were not importable modules.

I found [these lines](https://github.com/pyiron/pympipool/blob/2c616aced49e8d513f3fd18aefda6f2d0d41f4e8/pympipool/backend/serial.py#L24C2-L24C2) where `"."` is getting added to the pythonpath (similar for mpiexec), and notice that `pympipool` workflows follow a pattern of `cd tests; python -m unittest discover .`, while the centralized workflows skip the CI and simply invoke things in the pattern `python -m unittest discover tests`. From my experiments in `pyiron_workflow` it looks like this is what's making the difference.

Here I want to double check that hypothesis and test two-work arounds. If the hypothesis is correct, I'll open a corresponding issue.