### PR TITLE
Test on older version of OSX

### DIFF
--- a/.github/workflows/check-macos-latest.yml
+++ b/.github/workflows/check-macos-latest.yml
@@ -1,0 +1,34 @@
+# We are waiting on the macos-latest image to play nicely with MPI
+
+name: Is-macos-latest-working-yet
+
+on:
+  schedule:
+    - cron: '0 23 * * 2'
+
+jobs:
+  openmpi-on-macos-latest:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2.2.0
+      with:
+        python-version: "3.11"
+        mamba-version: "*"
+        channels: conda-forge
+        miniforge-variant: Mambaforge
+        channel-priority: strict
+        auto-update-conda: true
+        environment-file: .ci_support/environment-openmpi.yml
+    - name: Test
+      shell: bash -l {0}
+      timeout-minutes: 10
+      run: |
+        pip install versioneer[toml]==0.29
+        pip install . --no-deps --no-build-isolation
+        cd tests
+        python -m unittest discover .
+      env:
+        OMPI_MCA_plm: 'isolated'
+        OMPI_MCA_rmaps_base_oversubscribe: 'yes'
+        OMPI_MCA_btl_vader_single_copy_mechanism: 'none'

--- a/.github/workflows/check-macos-latest.yml
+++ b/.github/workflows/check-macos-latest.yml
@@ -5,6 +5,7 @@ name: Is-macos-latest-working-yet
 on:
   schedule:
     - cron: '0 23 * * 2'
+  workflow_dispatch:
 
 jobs:
   openmpi-on-macos-latest:

--- a/.github/workflows/check-macos-latest.yml
+++ b/.github/workflows/check-macos-latest.yml
@@ -6,10 +6,11 @@ on:
   schedule:
     - cron: '0 23 * * 2'
   workflow_dispatch:
+  pull_request:
 
 jobs:
   openmpi-on-macos-latest:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2.2.0

--- a/.github/workflows/check-macos-latest.yml
+++ b/.github/workflows/check-macos-latest.yml
@@ -6,11 +6,10 @@ on:
   schedule:
     - cron: '0 23 * * 2'
   workflow_dispatch:
-  pull_request:
 
 jobs:
   openmpi-on-macos-latest:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2.2.0

--- a/.github/workflows/unittest-mpich.yml
+++ b/.github/workflows/unittest-mpich.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - operating-system: macos-latest
+        - operating-system: macos-11
           python-version: '3.11'
           label: osx-64-py-3-11-mpich
           prefix: /Users/runner/miniconda3/envs/my-env

--- a/.github/workflows/unittest-openmpi.yml
+++ b/.github/workflows/unittest-openmpi.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - operating-system: macos-latest
+        - operating-system: macos-11
           python-version: '3.11'
           label: osx-64-py-3-11-openmpi
           prefix: /Users/runner/miniconda3/envs/my-env


### PR DESCRIPTION
As discussed in #191, it looks like the macos failures are fundamentally not our fault; ideally the runners would handle MPI nicely, but in the meantime I think it is preferable to test on an older version than not to test at all (not to mention much more convenient to not always be restarting tests).