### PR TITLE
Use mpiexec only for parallel execution

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,6 +50,7 @@ jobs:
         mpiexec -n 4 python -m mpi4py.futures tests/benchmark/llh.py mpi4py >> timing.log
         python tests/benchmark/llh.py pympipool >> timing.log
         cat timing.log
+        python -m unittest tests/benchmark/test_results.py
       env:
         OMPI_MCA_plm: 'isolated'
         OMPI_MCA_rmaps_base_oversubscribe: 'yes'

--- a/.github/workflows/benchmarl.yml
+++ b/.github/workflows/benchmarl.yml
@@ -1,0 +1,66 @@
+# This workflow is used to run the unittest of pyiron
+
+name: Benchmark
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        include:
+        - operating-system: ubuntu-latest
+          python-version: '3.12'
+          label: linux-64-py-3-12-openmpi
+          prefix: /Users/runner/miniconda3/envs/my-env
+          environment-file: .ci_support/environment-openmpi.yml
+
+        - operating-system: ubuntu-latest
+          python-version: '3.12'
+          label: linux-64-py-3-12-mpich
+          prefix: /usr/share/miniconda3/envs/my-env
+          environment-file: .ci_support/environment-mpich.yml
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2.2.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        mamba-version: "*"
+        channels: conda-forge
+        miniforge-variant: Mambaforge
+        channel-priority: strict
+        auto-update-conda: true
+        environment-file: ${{ matrix.environment-file }}
+    - name: Test
+      shell: bash -l {0}
+      timeout-minutes: 5
+      run: |
+        mamba install -y flux-core=0.58.0 coverage
+        pip install versioneer[toml]==0.29
+        pip install . --no-deps --no-build-isolation
+        python tests/benchmark/llh.py static
+        python tests/benchmark/llh.py process
+        python tests/benchmark/llh.py thread
+        mpiexec -n 4 python -m mpi4py.futures tests/benchmark/llh.py mpi4py
+        python tests/benchmark/llh.py pympipool
+      env:
+        OMPI_MCA_plm: 'isolated'
+        OMPI_MCA_rmaps_base_oversubscribe: 'yes'
+        OMPI_MCA_btl_vader_single_copy_mechanism: 'none'
+    - name: Test Flux
+      shell: bash -l {0}
+      timeout-minutes: 5
+      run: >
+        flux start
+        python tests/benchmark/llh.py flux
+      env:
+        OMPI_MCA_plm: 'isolated'
+        OMPI_MCA_rmaps_base_oversubscribe: 'yes'
+        OMPI_MCA_btl_vader_single_copy_mechanism: 'none'

--- a/.github/workflows/benchmarl.yml
+++ b/.github/workflows/benchmarl.yml
@@ -60,8 +60,12 @@ jobs:
       run: >
         flux start
         python tests/benchmark/llh.py flux >> timing.log
-        cat timing.log
       env:
         OMPI_MCA_plm: 'isolated'
         OMPI_MCA_rmaps_base_oversubscribe: 'yes'
         OMPI_MCA_btl_vader_single_copy_mechanism: 'none'
+    - name: Analyse log
+      shell: bash -l {0}
+      timeout-minutes: 5
+      run: |
+        cat timing.log

--- a/.github/workflows/benchmarl.yml
+++ b/.github/workflows/benchmarl.yml
@@ -42,7 +42,6 @@ jobs:
       shell: bash -l {0}
       timeout-minutes: 10
       run: |
-        mamba install -y flux-core=0.58.0 coverage
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation
         python tests/benchmark/llh.py static >> timing.log
@@ -50,22 +49,8 @@ jobs:
         python tests/benchmark/llh.py thread >> timing.log
         mpiexec -n 4 python -m mpi4py.futures tests/benchmark/llh.py mpi4py >> timing.log
         python tests/benchmark/llh.py pympipool >> timing.log
-      env:
-        OMPI_MCA_plm: 'isolated'
-        OMPI_MCA_rmaps_base_oversubscribe: 'yes'
-        OMPI_MCA_btl_vader_single_copy_mechanism: 'none'
-    - name: Test Flux
-      shell: bash -l {0}
-      timeout-minutes: 5
-      run: >
-        flux start
-        python tests/benchmark/llh.py flux >> timing.log
-      env:
-        OMPI_MCA_plm: 'isolated'
-        OMPI_MCA_rmaps_base_oversubscribe: 'yes'
-        OMPI_MCA_btl_vader_single_copy_mechanism: 'none'
-    - name: Analyse log
-      shell: bash -l {0}
-      timeout-minutes: 5
-      run: |
         cat timing.log
+      env:
+        OMPI_MCA_plm: 'isolated'
+        OMPI_MCA_rmaps_base_oversubscribe: 'yes'
+        OMPI_MCA_btl_vader_single_copy_mechanism: 'none'

--- a/.github/workflows/benchmarl.yml
+++ b/.github/workflows/benchmarl.yml
@@ -40,16 +40,16 @@ jobs:
         environment-file: ${{ matrix.environment-file }}
     - name: Test
       shell: bash -l {0}
-      timeout-minutes: 5
+      timeout-minutes: 10
       run: |
         mamba install -y flux-core=0.58.0 coverage
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation
-        python tests/benchmark/llh.py static
-        python tests/benchmark/llh.py process
-        python tests/benchmark/llh.py thread
-        mpiexec -n 4 python -m mpi4py.futures tests/benchmark/llh.py mpi4py
-        python tests/benchmark/llh.py pympipool
+        python tests/benchmark/llh.py static >> timing.log
+        python tests/benchmark/llh.py process >> timing.log
+        python tests/benchmark/llh.py thread >> timing.log
+        mpiexec -n 4 python -m mpi4py.futures tests/benchmark/llh.py mpi4py >> timing.log
+        python tests/benchmark/llh.py pympipool >> timing.log
       env:
         OMPI_MCA_plm: 'isolated'
         OMPI_MCA_rmaps_base_oversubscribe: 'yes'
@@ -59,7 +59,8 @@ jobs:
       timeout-minutes: 5
       run: >
         flux start
-        python tests/benchmark/llh.py flux
+        python tests/benchmark/llh.py flux >> timing.log
+        cat timing.log
       env:
         OMPI_MCA_plm: 'isolated'
         OMPI_MCA_rmaps_base_oversubscribe: 'yes'

--- a/pympipool/shared/interface.py
+++ b/pympipool/shared/interface.py
@@ -62,11 +62,9 @@ class MpiExecInterface(SubprocessInterface):
             cores=self._cores,
             oversubscribe=self._oversubscribe,
         )
-        command_final_lst = super().generate_command(
+        return super().generate_command(
             command_lst=command_prepend_lst + command_lst,
         )
-        print(command_final_lst)
-        return command_final_lst
 
 
 class SrunInterface(SubprocessInterface):

--- a/pympipool/shared/interface.py
+++ b/pympipool/shared/interface.py
@@ -62,9 +62,11 @@ class MpiExecInterface(SubprocessInterface):
             cores=self._cores,
             oversubscribe=self._oversubscribe,
         )
-        return super().generate_command(
+        command_final_lst = super().generate_command(
             command_lst=command_prepend_lst + command_lst,
         )
+        print(command_final_lst)
+        return command_final_lst
 
 
 class SrunInterface(SubprocessInterface):
@@ -98,10 +100,13 @@ class SrunInterface(SubprocessInterface):
 
 
 def generate_mpiexec_command(cores, oversubscribe=False):
-    command_prepend_lst = [MPI_COMMAND, "-n", str(cores)]
-    if oversubscribe:
-        command_prepend_lst += ["--oversubscribe"]
-    return command_prepend_lst
+    if cores == 1:
+        return []
+    else:
+        command_prepend_lst = [MPI_COMMAND, "-n", str(cores)]
+        if oversubscribe:
+            command_prepend_lst += ["--oversubscribe"]
+        return command_prepend_lst
 
 
 def generate_slurm_command(

--- a/tests/benchmark/llh.py
+++ b/tests/benchmark/llh.py
@@ -44,4 +44,4 @@ if __name__ == "__main__":
     else:
         raise ValueError(run_mode)
     stop_time = time()
-    print("Result:", stop_time-start_time)
+    print(run_mode, stop_time-start_time)

--- a/tests/benchmark/llh.py
+++ b/tests/benchmark/llh.py
@@ -1,0 +1,47 @@
+import sys
+from time import time
+
+
+def llh_numpy(mean, sigma):
+    import numpy
+    data = numpy.random.normal(size=100000000).astype('float64')
+    s = (data - mean) ** 2 / (2 * (sigma ** 2))
+    pdfs = numpy.exp(- s)
+    pdfs /= numpy.sqrt(2 * numpy.pi) * sigma
+    return numpy.log(pdfs).sum()
+
+
+def run_with_executor(executor=None, mean=0.1, sigma=1.1, runs=32, **kwargs):
+    with executor(**kwargs) as exe:
+        future_lst = [exe.submit(llh_numpy, mean=mean, sigma=sigma) for i in range(runs)]
+        return [f.result() for f in future_lst]
+
+
+def run_static(mean=0.1, sigma=1.1, runs=32):
+    return [llh_numpy(mean=mean, sigma=sigma) for i in range(runs)]
+
+
+if __name__ == "__main__":
+    run_mode = sys.argv[1]
+    start_time = time()
+    if run_mode == "static":
+        run_static(mean=0.1, sigma=1.1, runs=32)
+    elif run_mode == "process":
+        from concurrent.futures import ProcessPoolExecutor
+        run_with_executor(executor=ProcessPoolExecutor, mean=0.1, sigma=1.1, runs=32, max_workers=4)
+    elif run_mode == "thread":
+        from concurrent.futures import ThreadPoolExecutor
+        run_with_executor(executor=ThreadPoolExecutor, mean=0.1, sigma=1.1, runs=32, max_workers=4)
+    elif run_mode == "pympipool":
+        from pympipool.mpi.executor import PyMPIExecutor
+        run_with_executor(executor=PyMPIExecutor, mean=0.1, sigma=1.1, runs=32, max_workers=4)
+    elif run_mode == "flux":
+        from pympipool.flux.executor import PyFluxExecutor
+        run_with_executor(executor=PyFluxExecutor, mean=0.1, sigma=1.1, runs=32, max_workers=4)
+    elif run_mode == "mpi4py":
+        from mpi4py.futures import MPIPoolExecutor
+        run_with_executor(executor=MPIPoolExecutor, mean=0.1, sigma=1.1, runs=32, max_workers=4)
+    else:
+        raise ValueError(run_mode)
+    stop_time = time()
+    print("Result:", stop_time-start_time)

--- a/tests/benchmark/test_results.py
+++ b/tests/benchmark/test_results.py
@@ -1,0 +1,17 @@
+import unittest
+
+
+class TestResults(unittest.TestCase):
+    def test_result(self):
+        with open("timing.log") as f:
+            content = f.readlines()
+        timing_dict = {l.split()[0]: float(l.split()[1]) for l in content}
+        self.assertEqual(min(timing_dict, key=timing_dict.get), "process")
+        self.assertEqual(max(timing_dict, key=timing_dict.get), "static")
+        self.assertTrue(timing_dict["process"] < timing_dict["pympipool"])
+        self.assertTrue(timing_dict["pympipool"] < timing_dict["process"] * 1.1)
+        self.assertTrue(timing_dict["process"] < timing_dict["mpi4py"])
+        self.assertTrue(timing_dict["pympipool"] < timing_dict["mpi4py"])
+        self.assertTrue(timing_dict["mpi4py"] < timing_dict["process"] * 1.15)
+        self.assertTrue(timing_dict["thread"] < timing_dict["static"])
+        self.assertTrue(timing_dict["mpi4py"] < timing_dict["thread"])


### PR DESCRIPTION
@ligerzero-ai based on your performance analysis I designed a small benchmark. Using this benchmark I found the bug that is fixed with this pull request. The updated results of the benchmark are posted below. Now `pympipool` is competitive with the `ProcessPoolExecutor`. Can you test this branch with your own benchmark? 

# Code 
```
# Benchmark: 
# >>> python benchmark.py static
# Result: 79.38484382629395
# >>> python benchmark.py process
# Result: 33.66195225715637
# >>> python benchmark.py thread
# Result: 52.65341782569885
# >>> mpiexec -n 4 python -m mpi4py.futures benchmark.py mpi4py
# Result: 39.54463863372803
# >>> python benchmark.py pympipool
# Result: 34.79054880142212
# >>> python benchmark.py flux
# Result: 36.002100467681885

import sys
from time import time


def llh_numpy(mean, sigma):
    import numpy
    data = numpy.random.normal(size=100000000).astype('float64')
    s = (data - mean) ** 2 / (2 * (sigma ** 2))
    pdfs = numpy.exp(- s)
    pdfs /= numpy.sqrt(2 * numpy.pi) * sigma
    return numpy.log(pdfs).sum()


def run_with_executor(executor=None, mean=0.1, sigma=1.1, runs=32, **kwargs):
    with executor(**kwargs) as exe:
        future_lst = [exe.submit(llh_numpy, mean=mean, sigma=sigma) for i in range(runs)]
        return [f.result() for f in future_lst]


def run_static(mean=0.1, sigma=1.1, runs=32):
    return [llh_numpy(mean=mean, sigma=sigma) for i in range(runs)]


if __name__ == "__main__":
    run_mode = sys.argv[1]
    start_time = time()
    if run_mode == "static":
        run_static(mean=0.1, sigma=1.1, runs=32)
    elif run_mode == "process":
        from concurrent.futures import ProcessPoolExecutor
        run_with_executor(executor=ProcessPoolExecutor, mean=0.1, sigma=1.1, runs=32, max_workers=4)
    elif run_mode == "thread":
        from concurrent.futures import ThreadPoolExecutor
        run_with_executor(executor=ThreadPoolExecutor, mean=0.1, sigma=1.1, runs=32, max_workers=4)
    elif run_mode == "pympipool":
        from pympipool.mpi.executor import PyMPIExecutor
        run_with_executor(executor=PyMPIExecutor, mean=0.1, sigma=1.1, runs=32, max_workers=4)
    elif run_mode == "flux":
        from pympipool.flux.executor import PyFluxExecutor
        run_with_executor(executor=PyFluxExecutor, mean=0.1, sigma=1.1, runs=32, max_workers=4)
    elif run_mode == "mpi4py":
        from mpi4py.futures import MPIPoolExecutor
        run_with_executor(executor=MPIPoolExecutor, mean=0.1, sigma=1.1, runs=32, max_workers=4)
    else:
        raise ValueError(run_mode)
    stop_time = time()
    print("Result:", stop_time-start_time)
```

# Results

| Command                                                     | Runtime: cmpc06 [s] |
|-------------------------------------------------------------|---------------------|
| `python benchmark.py static`                                |  79.38484382629395  |
| `python benchmark.py process`                               |  33.66195225715637  |
| `python benchmark.py thread`                                |  52.65341782569885  |
| `mpiexec -n 4 python -m mpi4py.futures benchmark.py mpi4py` |  39.54463863372803  |
| `python benchmark.py pympipool`                             |  34.79054880142212  |
| `flux start; python benchmark.py flux`                      |  36.002100467681885 |