### PR TITLE
Add option to add additional arguments to SLURM submission scripts

### DIFF
--- a/pympipool/shared/interface.py
+++ b/pympipool/shared/interface.py
@@ -76,6 +76,7 @@ class SrunInterface(SubprocessInterface):
         threads_per_core=1,
         gpus_per_core=0,
         oversubscribe=False,
+        command_line_argument_lst=[],
     ):
         super().__init__(
             cwd=cwd,
@@ -84,6 +85,7 @@ class SrunInterface(SubprocessInterface):
         )
         self._threads_per_core = threads_per_core
         self._gpus_per_core = gpus_per_core
+        self._command_line_argument_lst = command_line_argument_lst
 
     def generate_command(self, command_lst):
         command_prepend_lst = generate_slurm_command(
@@ -92,6 +94,7 @@ class SrunInterface(SubprocessInterface):
             threads_per_core=self._threads_per_core,
             gpus_per_core=self._gpus_per_core,
             oversubscribe=self._oversubscribe,
+            command_line_argument_lst=self._command_line_argument_lst,
         )
         return super().generate_command(
             command_lst=command_prepend_lst + command_lst,
@@ -109,7 +112,7 @@ def generate_mpiexec_command(cores, oversubscribe=False):
 
 
 def generate_slurm_command(
-    cores, cwd, threads_per_core=1, gpus_per_core=0, oversubscribe=False
+    cores, cwd, threads_per_core=1, gpus_per_core=0, oversubscribe=False, command_line_argument_lst=[],
 ):
     command_prepend_lst = [SLURM_COMMAND, "-n", str(cores)]
     if cwd is not None:
@@ -120,4 +123,6 @@ def generate_slurm_command(
         command_prepend_lst += ["--gpus-per-task=" + str(gpus_per_core)]
     if oversubscribe:
         command_prepend_lst += ["--oversubscribe"]
+    if len(command_line_argument_lst) > 0:
+        command_prepend_lst += command_line_argument_lst
     return command_prepend_lst

--- a/pympipool/shared/interface.py
+++ b/pympipool/shared/interface.py
@@ -112,7 +112,12 @@ def generate_mpiexec_command(cores, oversubscribe=False):
 
 
 def generate_slurm_command(
-    cores, cwd, threads_per_core=1, gpus_per_core=0, oversubscribe=False, command_line_argument_lst=[],
+    cores,
+    cwd,
+    threads_per_core=1,
+    gpus_per_core=0,
+    oversubscribe=False,
+    command_line_argument_lst=[],
 ):
     command_prepend_lst = [SLURM_COMMAND, "-n", str(cores)]
     if cwd is not None:

--- a/pympipool/slurm/executor.py
+++ b/pympipool/slurm/executor.py
@@ -60,6 +60,7 @@ class PySlurmExecutor(ExecutorBroker):
         init_function=None,
         cwd=None,
         hostname_localhost=False,
+        command_line_argument_lst=[],
     ):
         super().__init__()
         self._set_process(
@@ -78,6 +79,7 @@ class PySlurmExecutor(ExecutorBroker):
                         "gpus_per_core": int(gpus_per_worker / cores_per_worker),
                         "cwd": cwd,
                         "oversubscribe": oversubscribe,
+                        "command_line_argument_lst": command_line_argument_lst,
                     },
                 )
                 for _ in range(max_workers)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -69,3 +69,47 @@ class TestParser(unittest.TestCase):
             ),
         )
         self.assertEqual(result_dict, parse_arguments(command_lst))
+
+    def test_command_slurm_user_command(self):
+        result_dict = {
+            "host": "127.0.0.1",
+            "zmqport": "22",
+        }
+        command_lst = [
+            "srun",
+            "-n",
+            "2",
+            "-D",
+            os.path.abspath("."),
+            "--gpus-per-task=1",
+            "--oversubscribe",
+            "--account=test",
+            "--job-name=pympipool",
+            sys.executable,
+            "/",
+            "--host",
+            result_dict["host"],
+            "--zmqport",
+            result_dict["zmqport"],
+        ]
+        interface = SrunInterface(
+            cwd=os.path.abspath("."),
+            cores=2,
+            gpus_per_core=1,
+            oversubscribe=True,
+            command_line_argument_lst=["--account=test", "--job-name=pympipool"],
+        )
+        self.assertEqual(
+            command_lst,
+            interface.generate_command(
+                command_lst=[
+                    sys.executable,
+                    "/",
+                    "--host",
+                    result_dict["host"],
+                    "--zmqport",
+                    result_dict["zmqport"],
+                ]
+            ),
+        )
+        self.assertEqual(result_dict, parse_arguments(command_lst))


### PR DESCRIPTION
@mgt16-LANL I added a first draft to support additional SLURM command line arguments, does this address your request in https://github.com/pyiron/pympipool/issues/281 ? 