### PR TITLE
Add max_workers parameter for backwards compatiblity

### DIFF
--- a/pympipool/__init__.py
+++ b/pympipool/__init__.py
@@ -19,6 +19,9 @@ class Executor:
     an interactive Jupyter notebook.
 
     Args:
+        max_workers (int): for backwards compatibility with the standard library, max_workers also defines the number of
+                           cores which can be used in parallel - just like the max_cores parameter. Using max_cores is
+                           recommended, as computers have a limited number of compute cores.
         max_cores (int): defines the number cores which can be used in parallel
         cores_per_worker (int): number of MPI cores to be used for each function call
         threads_per_core (int): number of OpenMP threads to be used for each function call
@@ -64,6 +67,7 @@ class Executor:
 
     def __init__(
         self,
+        max_workers: int = 1,
         max_cores: int = 1,
         cores_per_worker: int = 1,
         threads_per_core: int = 1,
@@ -84,6 +88,7 @@ class Executor:
 
     def __new__(
         cls,
+        max_workers: int = 1,
         max_cores: int = 1,
         cores_per_worker: int = 1,
         threads_per_core: int = 1,
@@ -108,6 +113,9 @@ class Executor:
         requires the SLURM workload manager to be installed on the system.
 
         Args:
+            max_workers (int): for backwards compatibility with the standard library, max_workers also defines the
+                               number of cores which can be used in parallel - just like the max_cores parameter. Using
+                               max_cores is recommended, as computers have a limited number of compute cores.
             max_cores (int): defines the number cores which can be used in parallel
             cores_per_worker (int): number of MPI cores to be used for each function call
             threads_per_core (int): number of OpenMP threads to be used for each function call

--- a/pympipool/__init__.py
+++ b/pympipool/__init__.py
@@ -143,6 +143,7 @@ class Executor:
         """
         if not disable_dependencies:
             return ExecutorWithDependencies(
+                max_workers=max_workers,
                 max_cores=max_cores,
                 cores_per_worker=cores_per_worker,
                 threads_per_core=threads_per_core,
@@ -160,6 +161,7 @@ class Executor:
         else:
             _check_refresh_rate(refresh_rate=refresh_rate)
             return create_executor(
+                max_workers=max_workers,
                 max_cores=max_cores,
                 cores_per_worker=cores_per_worker,
                 threads_per_core=threads_per_core,

--- a/pympipool/shared/inputcheck.py
+++ b/pympipool/shared/inputcheck.py
@@ -83,5 +83,5 @@ def check_init_function(block_allocation, init_function):
 def validate_number_of_cores(max_cores, max_workers):
     # only overwrite max_cores when it is set to 1
     if max_workers != 1 and max_cores == 1:
-        max_cores = max_workers
+        return max_workers
     return max_cores

--- a/pympipool/shared/inputcheck.py
+++ b/pympipool/shared/inputcheck.py
@@ -78,3 +78,10 @@ def check_backend(backend):
 def check_init_function(block_allocation, init_function):
     if not block_allocation and init_function is not None:
         raise ValueError("")
+
+
+def validate_number_of_cores(max_cores, max_workers):
+    # only overwrite max_cores when it is set to 1
+    if max_workers != 1 and max_cores == 1:
+        max_cores = max_workers
+    return max_cores

--- a/tests/test_executor_backend_mpi.py
+++ b/tests/test_executor_backend_mpi.py
@@ -43,7 +43,7 @@ class TestExecutorBackend(unittest.TestCase):
 
     def test_meta_executor_parallel(self):
         with Executor(
-            max_cores=2,
+            max_workers=2,
             cores_per_worker=2,
             hostname_localhost=True,
             backend="mpi",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a new parameter `max_workers` to the `Executor` class, enabling users to define the number of cores for parallel processing.
- **Enhancements**
	- Enhanced core validation to recommend using `max_cores` over `max_workers` for optimal resource utilization.
- **Tests**
	- Updated tests to align with modifications in the `Executor` class, ensuring the accuracy and effectiveness of parallel execution functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->